### PR TITLE
Dont push docker image for dependabot

### DIFF
--- a/.github/workflows/next-app.yaml
+++ b/.github/workflows/next-app.yaml
@@ -61,7 +61,7 @@ jobs:
           VAR: image=${{ needs.build-dev.outputs.image }},version=${{ github.sha }}
 
   build-demo:
-    if: github.ref_name == 'main' || startsWith(github.ref_name, 'demo') && github.actor != 'dependabot[bot]'
+    if: github.ref_name == 'main' || startsWith(github.ref_name, 'demo')
     name: Build for demo
     runs-on: ubuntu-latest
     permissions:
@@ -81,7 +81,7 @@ jobs:
           NPM_AUTH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
   deploy-demo-main:
-    if: github.ref_name == 'main' && github.actor != 'dependabot[bot]'
+    if: github.ref_name == 'main'
     name: Deploy main to demo
     environment:
       name: demo-main
@@ -98,7 +98,7 @@ jobs:
           VAR: image=${{ needs.build-demo.outputs.image }},ingress=https://demo.ekstern.dev.nav.no${{ inputs.base-path }},appname=${{ inputs.app }},replicas=1,branchState=alive
 
   deploy-demo-branch:
-    if: startsWith(github.ref_name, 'demo') && github.actor != 'dependabot[bot]'
+    if: startsWith(github.ref_name, 'demo')
     name: Deploy branch to demo
     environment:
       name: demo-branch
@@ -119,7 +119,7 @@ jobs:
           VAR: image=${{ needs.build-demo.outputs.image }},ingress=https://${{ steps.slug.outputs.slug }}.ekstern.dev.nav.no${{ inputs.base-path }},appname=${{ steps.slug.outputs.slug }},replicas=1,branchState=alive
 
   build-prod:
-    if: github.ref_name == 'main' && github.actor != 'dependabot[bot]'
+    if: github.ref_name == 'main'
     name: Build for prod
     runs-on: ubuntu-latest
     permissions:
@@ -139,7 +139,7 @@ jobs:
           NPM_AUTH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
   deploy-prod:
-    if: github.ref_name == 'main' && github.actor != 'dependabot[bot]'
+    if: github.ref_name == 'main'
     name: Deploy to prod
     environment:
       name: production

--- a/.github/workflows/next-app.yaml
+++ b/.github/workflows/next-app.yaml
@@ -20,7 +20,7 @@ jobs:
       - run: npm run test
 
   build-dev:
-    if: ${{ !startsWith(github.ref_name, 'demo') }}
+    if: ${{ !startsWith(github.ref_name, 'demo') }} && github.actor != 'dependabot[bot]'
     name: Build for dev
     runs-on: ubuntu-latest
     permissions:
@@ -40,7 +40,7 @@ jobs:
           NPM_AUTH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
   deploy-dev:
-    if: ${{ !startsWith(github.ref_name, 'demo') }}
+    if: ${{ !startsWith(github.ref_name, 'demo') }} && github.actor != 'dependabot[bot]'
     name: Deploy to dev
     environment:
       name: development
@@ -61,7 +61,7 @@ jobs:
           VAR: image=${{ needs.build-dev.outputs.image }},version=${{ github.sha }}
 
   build-demo:
-    if: github.ref_name == 'main' || startsWith(github.ref_name, 'demo')
+    if: github.ref_name == 'main' || startsWith(github.ref_name, 'demo') && github.actor != 'dependabot[bot]'
     name: Build for demo
     runs-on: ubuntu-latest
     permissions:
@@ -81,7 +81,7 @@ jobs:
           NPM_AUTH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
   deploy-demo-main:
-    if: github.ref_name == 'main'
+    if: github.ref_name == 'main' && github.actor != 'dependabot[bot]'
     name: Deploy main to demo
     environment:
       name: demo-main
@@ -98,7 +98,7 @@ jobs:
           VAR: image=${{ needs.build-demo.outputs.image }},ingress=https://demo.ekstern.dev.nav.no${{ inputs.base-path }},appname=${{ inputs.app }},replicas=1,branchState=alive
 
   deploy-demo-branch:
-    if: startsWith(github.ref_name, 'demo')
+    if: startsWith(github.ref_name, 'demo') && github.actor != 'dependabot[bot]'
     name: Deploy branch to demo
     environment:
       name: demo-branch
@@ -119,7 +119,7 @@ jobs:
           VAR: image=${{ needs.build-demo.outputs.image }},ingress=https://${{ steps.slug.outputs.slug }}.ekstern.dev.nav.no${{ inputs.base-path }},appname=${{ steps.slug.outputs.slug }},replicas=1,branchState=alive
 
   build-prod:
-    if: github.ref_name == 'main'
+    if: github.ref_name == 'main' && github.actor != 'dependabot[bot]'
     name: Build for prod
     runs-on: ubuntu-latest
     permissions:
@@ -139,7 +139,7 @@ jobs:
           NPM_AUTH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
   deploy-prod:
-    if: github.ref_name == 'main'
+    if: github.ref_name == 'main' && github.actor != 'dependabot[bot]'
     name: Deploy to prod
     environment:
       name: production


### PR DESCRIPTION
Dependabot har ikke tilgang til secrets, og kan derfor ikke pushe image. Derfor feiler builds for dependabot.

Andre teams har "fikset" dependabot på litt ulike måter, men enkleste er at dependabot kun kjører npm run build, test osv - som ikke krever secrets.