### PR TITLE
Add dependency graph generation

### DIFF
--- a/.github/workflows/boot-jar-app.yaml
+++ b/.github/workflows/boot-jar-app.yaml
@@ -10,7 +10,7 @@ jobs:
     runs-on: ubuntu-latest
     permissions:
       actions: read
-      contents: read
+      contents: write
       security-events: write
     strategy:
       fail-fast: false

--- a/.github/workflows/boot-jar-app.yaml
+++ b/.github/workflows/boot-jar-app.yaml
@@ -10,7 +10,7 @@ jobs:
     runs-on: ubuntu-latest
     permissions:
       actions: read
-      contents: write
+      contents: read
       security-events: write
     strategy:
       fail-fast: false
@@ -53,9 +53,9 @@ jobs:
     name: Build
     runs-on: ubuntu-latest
     permissions:
-      packages: "write"
-      contents: "read"
-      id-token: "write"
+      packages: write
+      contents: write
+      id-token: write
     outputs:
       image: ${{ steps.build-and-publish.outputs.image }}
     steps:

--- a/.github/workflows/fss-boot-jar-app.yaml
+++ b/.github/workflows/fss-boot-jar-app.yaml
@@ -53,9 +53,9 @@ jobs:
     name: Build
     runs-on: ubuntu-latest
     permissions:
-      packages: "write"
-      contents: "write"
-      id-token: "write"
+      packages: write
+      contents: write
+      id-token: write
     outputs:
       image: ${{ steps.build-and-publish.outputs.image }}
     steps:

--- a/.github/workflows/fss-jar-app.yaml
+++ b/.github/workflows/fss-jar-app.yaml
@@ -17,18 +17,14 @@ jobs:
       fail-fast: false
     steps:
       - uses: actions/checkout@v3
-
       - uses: github/codeql-action/init@v2
         with:
           languages: kotlin
-
       - uses: navikt/teamesyfo-github-actions-workflows/actions/gradle-cached@main
-
       - run: ./gradlew shadowJar -x test
         env:
           ORG_GRADLE_PROJECT_githubUser: x-access-token
           ORG_GRADLE_PROJECT_githubPassword: ${{ secrets.GITHUB_TOKEN }}
-
       - uses: github/codeql-action/analyze@v2
         with:
           category: "/language:kotlin"
@@ -47,9 +43,9 @@ jobs:
     name: Build
     runs-on: ubuntu-latest
     permissions:
-      packages: "write"
-      contents: "read"
-      id-token: "write"
+      packages: write
+      contents: write
+      id-token: write
     outputs:
       image: ${{ steps.build-and-publish.outputs.image }}
     steps:

--- a/.github/workflows/jar-app.yaml
+++ b/.github/workflows/jar-app.yaml
@@ -10,7 +10,7 @@ jobs:
     runs-on: ubuntu-latest
     permissions:
       actions: read
-      contents: write
+      contents: read
       security-events: write
     strategy:
       fail-fast: false
@@ -42,9 +42,9 @@ jobs:
     name: Build
     runs-on: ubuntu-latest
     permissions:
-      packages: "write"
-      contents: "read"
-      id-token: "write"
+      packages: write
+      contents: write
+      id-token: write
     outputs:
       image: ${{ steps.build-and-publish.outputs.image }}
     steps:

--- a/.github/workflows/jar-app.yaml
+++ b/.github/workflows/jar-app.yaml
@@ -10,7 +10,7 @@ jobs:
     runs-on: ubuntu-latest
     permissions:
       actions: read
-      contents: read
+      contents: write
       security-events: write
     strategy:
       fail-fast: false

--- a/actions/boot-jar-to-docker/action.yaml
+++ b/actions/boot-jar-to-docker/action.yaml
@@ -23,6 +23,8 @@ runs:
   using: "composite"
   steps:
     - uses: navikt/teamesyfo-github-actions-workflows/actions/gradle-cached@main
+      with:
+        dependency-graph: generate-and-submit
     - name: Build bootJar
       env:
         ORG_GRADLE_PROJECT_githubUser: x-access-token

--- a/actions/gradle-cached/action.yaml
+++ b/actions/gradle-cached/action.yaml
@@ -1,6 +1,12 @@
 name: "Installs java, validates gradle wrapper, installs gradle dependencies with cache"
 description: "Installs java, validates gradle wrapper, installs gradle dependencies with cache"
 
+inputs:
+  dependency-graph:
+    description: 'Possible values: generate, generate-and-submit and download-and-submit. Default value is disabled. Only applicable to main branch'
+    required: false
+    default: disabled
+
 runs:
   using: "composite"
   steps:
@@ -22,4 +28,4 @@ runs:
         ORG_GRADLE_PROJECT_githubPassword: ${{ inputs.github_token }}
       uses: gradle/gradle-build-action@v2
       with:
-        dependency-graph: generate-and-submit
+        dependency-graph: ${{ inputs.dependency-graph }}

--- a/actions/gradle-cached/action.yaml
+++ b/actions/gradle-cached/action.yaml
@@ -13,4 +13,13 @@ runs:
     - uses: gradle/wrapper-validation-action@v1.1.0
       id: gradle-wrapper-validation
     - name: Setup Gradle
+      if: github.ref_name != 'main'
       uses: gradle/gradle-build-action@v2
+    - name: Setup Gradle with dependency generation
+      if: github.ref_name == 'main'
+      env:
+        ORG_GRADLE_PROJECT_githubUser: x-access-token
+        ORG_GRADLE_PROJECT_githubPassword: ${{ inputs.github_token }}
+      uses: gradle/gradle-build-action@v2
+      with:
+        dependency-graph: generate-and-submit

--- a/actions/jar-to-docker/action.yaml
+++ b/actions/jar-to-docker/action.yaml
@@ -23,6 +23,8 @@ runs:
   using: "composite"
   steps:
     - uses: navikt/teamesyfo-github-actions-workflows/actions/gradle-cached@main
+      with:
+        dependency-graph: generate-and-submit
     - name: Build jar
       env:
         ORG_GRADLE_PROJECT_githubUser: x-access-token


### PR DESCRIPTION
Genererer dependency graph og sender det til Github via Github Dependency Submission API, slik at dependencies dukker opp under Insights > Dependency graph. Det er en forutsetning for at Dependabot kan lage issues/pr.