### PR TITLE
Let Dependabot scan actions in specified folders

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -5,3 +5,27 @@ updates:
     directory: '/'
     schedule:
       interval: daily
+  - package-ecosystem: github-actions
+    directory: '/actions/boot-jar-to-docker'
+    schedule:
+      interval: daily
+  - package-ecosystem: github-actions
+    directory: '/actions/gradle-cached'
+    schedule:
+      interval: daily
+  - package-ecosystem: github-actions
+    directory: '/actions/gradle-cached-21'
+    schedule:
+      interval: daily
+  - package-ecosystem: github-actions
+    directory: '/actions/jar-to-docker'
+    schedule:
+      interval: daily
+  - package-ecosystem: github-actions
+    directory: '/actions/next-to-docker'
+    schedule:
+      interval: daily
+  - package-ecosystem: github-actions
+    directory: '/actions/npm-cached'
+    schedule:
+      interval: daily


### PR DESCRIPTION
Det viser seg at den nåværende configen til Dependabot ikke inkluderer alle github-actions som ligger i /actions/*/action.yaml. Det gjør at Dependabot ikke foreslår å bumpe versjoner av github-actions som ligger i under /actions-folderen. Det kan man se ved at man får warnings når andre prosjekt bygger, feks:
`Node.js 16 actions are deprecated. Please update the following actions to use Node.js 20: actions/checkout@v3`

Jeg tror denne configen skal inkludere alle disse, men får ikke sjekket om det fungerer før det er merget.

Dessverre støtter ikke configen wildcard eller liste over directories ennå, så da må det settes opp slik som dette foreløpig.