### PR TITLE
Add github credentials to detekt step

### DIFF
--- a/.github/workflows/boot-jar-app-21.yaml
+++ b/.github/workflows/boot-jar-app-21.yaml
@@ -30,6 +30,9 @@ jobs:
           languages: ${{ matrix.language }}
       - name: Run detekt
         run: ./gradlew detekt
+        env:
+          ORG_GRADLE_PROJECT_githubUser: x-access-token
+          ORG_GRADLE_PROJECT_githubPassword: ${{ secrets.GITHUB_TOKEN }}
       - name: Build bootJar artifacts
         run: |
           ./gradlew bootJar -x test


### PR DESCRIPTION
Ser ut til at man trenger å legge til githubuser for å kjøre detekt-steget i syfomotebehov