### PR TITLE
Use a dummy image in delete-demo-app job

### DIFF
--- a/.github/workflows/next-app-demo-delete.yaml
+++ b/.github/workflows/next-app-demo-delete.yaml
@@ -22,4 +22,4 @@ jobs:
         env:
           CLUSTER: dev-gcp
           RESOURCE: nais/nais-demo.yaml
-          VAR: image=ghcr.io/navikt/${{ inputs.app }}:latest,ingress=https://${{ inputs.app }}-${{ steps.slug.outputs.branch-name-slug }}.ekstern.dev.nav.no${{ inputs.base-path }},appname=${{ inputs.app}}-${{ steps.slug.outputs.branch-name-slug }},replicas=0,branchState=deleted
+          VAR: image=redis:latest,ingress=https://${{ inputs.app }}-${{ steps.slug.outputs.branch-name-slug }}.ekstern.dev.nav.no${{ inputs.base-path }},appname=${{ inputs.app}}-${{ steps.slug.outputs.branch-name-slug }},replicas=0,branchState=deleted


### PR DESCRIPTION
This job is failing now because the image is not in GHCR, because we don't publish (?) the image there anymore (we use GAR now). The image isn't used for anything in this job however.

Trying to see if this fixes the problem.