### PR TITLE
fix: add --no-daemon and clean to gradle build for CodeQL

### DIFF
--- a/.github/workflows/jar-app.yaml
+++ b/.github/workflows/jar-app.yaml
@@ -28,7 +28,7 @@ jobs:
           java-version: ${{inputs.java-version}}
       - name: Build shadowJar
         shell: bash
-        run: ./gradlew shadowJar -x test
+        run: ./gradlew clean shadowJar -x test --no-daemon
         env:
           JAVA_OPTS: "-Xmx2g -XX:MaxMetaspaceSize=1g"
           ORG_GRADLE_PROJECT_githubUser: x-access-token


### PR DESCRIPTION
Attempt fixing CodeQL error code 32 (No source code seen during build).

Documentation: https://docs.github.com/en/code-security/code-scanning/troubleshooting-code-scanning/no-source-code-seen-during-build