### PR TITLE
fix: add --no-build-cache to gradle build for CodeQL

### DIFF
--- a/.github/workflows/jar-app.yaml
+++ b/.github/workflows/jar-app.yaml
@@ -28,7 +28,7 @@ jobs:
           java-version: ${{inputs.java-version}}
       - name: Build shadowJar
         shell: bash
-        run: ./gradlew clean shadowJar -x test --no-daemon
+        run: ./gradlew clean shadowJar -x test --no-daemon --no-build-cache
         env:
           JAVA_OPTS: "-Xmx2g -XX:MaxMetaspaceSize=1g"
           ORG_GRADLE_PROJECT_githubUser: x-access-token


### PR DESCRIPTION
Fixes CodeQL error code 32 by disabling the gradle build cache.

The error 'No source code seen during build' occurred because Gradle was using cached compilation results ('FROM-CACHE'), preventing CodeQL from observing the compiler activity. Adding '--no-build-cache' forces a full recompilation.