### PR TITLE
Use the binaries bundled with codeql action

### DIFF
--- a/.github/workflows/jar-app.yaml
+++ b/.github/workflows/jar-app.yaml
@@ -23,6 +23,7 @@ jobs:
       - uses: github/codeql-action/init@v4
         with:
           languages: kotlin
+          tools: linked
       - uses: navikt/teamesyfo-github-actions-workflows/actions/gradle-cached@main
         with:
           java-version: ${{inputs.java-version}}


### PR DESCRIPTION
## Bakgrunn: Støtte for statisk analyse av Kotlin 2.3.x

Det er nå fire forskjellige hovedaktører involvert for analysen av Kotlin

1. Kotlin selv
2. CodeQL
3. CodeQL Github Action
4. Github Actions Runner-en (containeren som kjører actions)

CodeQL merget støtte for Kotlin 2.3.0 i 2.2.41 5/2. 
CodeQL Action merget nyeste versjon av CodeQL bins i versjon 4.32.2 5/2

CodeQL Action bruker imidlertid binaries for CodeQL installert i runneren som default, og nyeste [Ubuntu runner](https://arc.net/l/quote/wnzjcuqx) runner bruker fortsatt 2.2.40.
Ved å sette `tools: linked` parameteret, benyttes binaries bundlet med CodeQL action - som er den nyeste versjonen som støtter denne minor-versjonen av Kotlin.  

Mulig det kan gå noe på bekostning av ytelse ved å gjøre det på denne måten, men med så mange aktører i sving for at vi skal kunne holde oss noen lunde oppdatert på Kotlin-versjoneringen mener jeg vi fint kan kutte ut et ledd og leve med noen ms lengre bygg-tid.

[Hele tråden i CodeQL](https://github.com/github/codeql/issues/20661)


 