### PR TITLE
Update README to remove pinning comment

### DIFF
--- a/README.md
+++ b/README.md
@@ -127,7 +127,6 @@ jobs:
     permissions:
       contents: write
       pull-requests: write
-    # Prefer pinning to a tag/SHA; @main is easier but less controlled.
     uses: navikt/teamesyfo-github-actions-workflows/.github/workflows/dependabot-automerge.yaml@main
 ```
 


### PR DESCRIPTION
Removed comment about pinning to a tag/SHA in README.