### PR TITLE
fix: skip commit signature verification in dependabot-automerge

### DIFF
--- a/.github/workflows/dependabot-automerge.yaml
+++ b/.github/workflows/dependabot-automerge.yaml
@@ -46,6 +46,8 @@ jobs:
       - name: Fetch Dependabot metadata
         id: dependabot-metadata
         uses: dependabot/fetch-metadata@21025c705c08248db411dc16f3619e6b5f9ea21a # v2.5.0
+        with:
+          skip-commit-verification: true
 
       - name: Decide auto-merge policy
         id: policy


### PR DESCRIPTION
## Problem

`dependabot/fetch-metadata` verifiserer GPG-signaturen på Dependabot-commits som standard. Enkelte Dependabot-commits har signaturer som GitHub ikke klarer å verifisere, noe som gjør at action-en feiler med:

```
⚠️ Dependabot's commit signature is not verified, refusing to proceed.
❌ PR is not from Dependabot, nothing to do.
```

Dette blokkerer hele automerge-workflowen selv om PR-en faktisk er fra Dependabot.

**Eksempel:** [navikt/syfo-oppfolgingsplan-frontend PR #658](https://github.com/navikt/syfo-oppfolgingsplan-frontend/actions/runs/22905140594/job/66461649291?pr=658)

## Løsning

Setter `skip-commit-verification: true` på `dependabot/fetch-metadata`-steget.

## Hvorfor er dette trygt?

Jobben har allerede en `if`-betingelse som sikrer at kun Dependabot-PRs behandles:

```yaml
if: github.event.pull_request.user.login == 'dependabot[bot]' && !github.event.pull_request.head.repo.fork
```

Denne betingelsen bruker GitHub API-data (ikke commit-signaturen) for å verifisere at PR-en kommer fra Dependabot, og at den ikke er fra en fork. Commit-signaturverifiseringen er dermed et redundant sjekk-lag som i praksis bare skaper falske negativer.