### PR TITLE
Tillat major-automerge for GitHub Actions, behold patch/minor for resten

### DIFF
--- a/.github/workflows/dependabot-automerge.yaml
+++ b/.github/workflows/dependabot-automerge.yaml
@@ -1,8 +1,10 @@
 name: Dependabot auto-approve and auto-merge
 
-# Reusable workflow that auto-approves and enables auto-merge for safe
-# Dependabot PRs (patch and minor updates). Major updates are left for
-# manual review.
+# Reusable workflow that auto-approves and enables auto-merge for
+# Dependabot PRs. GitHub Actions updates are always automerged (including
+# major), while other ecosystems (npm, Maven, etc.) are limited to
+# patch and minor updates. Required status checks (CI) act as the
+# safety gate.
 #
 # Prerequisites (recommended):
 #   - Branch protection with required status checks (e.g. a CI merge gate)
@@ -53,17 +55,23 @@ jobs:
         run: |
           set -euo pipefail
 
+          ecosystem='${{ steps.dependabot-metadata.outputs.package-ecosystem }}'
           update_type='${{ steps.dependabot-metadata.outputs.update-type }}'
+          echo "Package ecosystem: $ecosystem"
           echo "Update type: $update_type"
 
-          if [[ "$update_type" == "version-update:semver-patch" || "$update_type" == "version-update:semver-minor" ]]; then
+          if [[ "$ecosystem" == "github_actions" ]]; then
+            echo "GitHub Actions update — always auto-merge."
+            echo "should_automerge=true" >> "$GITHUB_OUTPUT"
+          elif [[ "$update_type" == "version-update:semver-patch" || "$update_type" == "version-update:semver-minor" ]]; then
+            echo "Patch/minor update — auto-merge."
             echo "should_automerge=true" >> "$GITHUB_OUTPUT"
           else
-            echo "Major or unknown update — skipping auto-merge."
+            echo "Major non-Actions update — skipping auto-merge."
             echo "should_automerge=false" >> "$GITHUB_OUTPUT"
           fi
 
-      - name: Approve PR if safe
+      - name: Approve PR
         if: ${{ steps.policy.outputs.should_automerge == 'true' }}
         env:
           PR_URL: ${{ github.event.pull_request.html_url }}
@@ -72,12 +80,12 @@ jobs:
           set -euo pipefail
           decision="$(gh pr view "$PR_URL" --json reviewDecision -q .reviewDecision)"
           if [[ "$decision" != "APPROVED" ]]; then
-            gh pr review --approve "$PR_URL" -b "Auto-approving safe Dependabot update (patch/minor)."
+            gh pr review --approve "$PR_URL" -b "Auto-approving Dependabot ${{ steps.dependabot-metadata.outputs.package-ecosystem }} ${{ steps.dependabot-metadata.outputs.update-type }} update."
           else
             echo "PR already approved."
           fi
 
-      - name: Enable auto-merge if safe
+      - name: Enable auto-merge
         if: ${{ steps.policy.outputs.should_automerge == 'true' }}
         env:
           PR_URL: ${{ github.event.pull_request.html_url }}


### PR DESCRIPTION
## Endring

Oppdaterer automerge-policyen slik at **GitHub Actions-oppdateringer alltid automerges** (inkludert major), mens andre ecosystems (Gradle, npm, etc.) beholder eksisterende patch/minor-filter.

## Bakgrunn

GitHub Actions major-bumps (f.eks. `upload-pages-artifact` v3→v4) brekker sjelden, og når de gjør det feiler CI — som blokkerer merge. Å filtrere bort major for actions skaper unødvendig PR-støy uten reell sikkerhetsgevinst.

## Hva endres

- **Ny logikk i policy-steget**: Sjekker `package-ecosystem` fra `dependabot/fetch-metadata`. Hvis `github_actions` → automerge uansett. Ellers → kun patch/minor som før.
- **Bedre approve-melding**: Inkluderer ecosystem og update-type (f.eks. *"Auto-approving Dependabot github_actions version-update:semver-major update"*) for sporbarhet.

## Blast radius

Denne reusable workflowen brukes av ~22 repos. Endringen er konservativ — den *utvider* kun automerge for GitHub Actions, alt annet er uendret.

## Forutsetning

Required status checks (CI) må være konfigurert i consumer-repoene. Uten dette kan PRer merges uten validering — men dette gjelder allerede for patch/minor også.