### PR TITLE
build(deps): bump pnpm/action-setup from v4 to v5

### DIFF
--- a/actions/setup-pnpm/action.yaml
+++ b/actions/setup-pnpm/action.yaml
@@ -13,7 +13,7 @@ runs:
   using: "composite"
   steps:
     - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
-    - uses: pnpm/action-setup@c5ba7f7862a0f64c1b1a05fbac13e0b8e86ba08c # v4
+    - uses: pnpm/action-setup@fc06bc1257f339d1d5d8b3a19a8cae5388b55320 # v5
     - uses: actions/setup-node@53b83947a5a98c8d113130e565377fae1a50d02f # v6
       with:
         node-version: ${{ inputs.node-version }}


### PR DESCRIPTION
## Summary
- bump `pnpm/action-setup` from v4 to v5.0.0 in `actions/setup-pnpm/action.yaml`
- note that upstream `pnpm/action-setup` v5 uses the Node.js 24 runtime
- replace Dependabot PR #124, which had a merge conflict

Supersedes #124