### PR TITLE
feat(ci): add Merge gate job to reusable workflows

### DIFF
--- a/.github/workflows/boot-jar-app.yaml
+++ b/.github/workflows/boot-jar-app.yaml
@@ -76,6 +76,7 @@ jobs:
     name: Merge gate
     needs: [analyze, test, build]
     runs-on: ubuntu-latest
+    permissions: {}
     if: always()
     steps:
       - name: Check required jobs
@@ -84,7 +85,6 @@ jobs:
           set -euo pipefail
 
           # Single required check for branch protection.
-          # Accept "skipped" for conditionally-run jobs.
           results=(
             "analyze=${{ needs.analyze.result }}"
             "test=${{ needs.test.result }}"
@@ -95,7 +95,7 @@ jobs:
           for r in "${results[@]}"; do
             status="${r#*=}"
             case "$status" in
-              success|skipped) ;;
+              success) ;;
               cancelled)
                 echo "::error::Required job was cancelled: $r"
                 exit 1

--- a/.github/workflows/boot-jar-app.yaml
+++ b/.github/workflows/boot-jar-app.yaml
@@ -72,6 +72,41 @@ jobs:
           github_token: ${{ secrets.GITHUB_TOKEN }}
           java-version: ${{inputs.java-version}}
 
+  merge-gate:
+    name: Merge gate
+    needs: [analyze, test, build]
+    runs-on: ubuntu-latest
+    if: always()
+    steps:
+      - name: Check required jobs
+        shell: bash
+        run: |
+          set -euo pipefail
+
+          # Single required check for branch protection.
+          # Accept "skipped" for conditionally-run jobs.
+          results=(
+            "analyze=${{ needs.analyze.result }}"
+            "test=${{ needs.test.result }}"
+            "build=${{ needs.build.result }}"
+          )
+          printf '%s\n' "${results[@]}"
+
+          for r in "${results[@]}"; do
+            status="${r#*=}"
+            case "$status" in
+              success|skipped) ;;
+              cancelled)
+                echo "::error::Required job was cancelled: $r"
+                exit 1
+                ;;
+              *)
+                echo "::error::Required job failed: $r"
+                exit 1
+                ;;
+            esac
+          done
+
   deploy-dev:
     if: ${{ github.actor != 'dependabot[bot]' && github.event.pull_request.draft == false }}
     name: Deploy to dev

--- a/.github/workflows/jar-app.yaml
+++ b/.github/workflows/jar-app.yaml
@@ -71,6 +71,7 @@ jobs:
     name: Merge gate
     needs: [analyze, test, build]
     runs-on: ubuntu-latest
+    permissions: {}
     if: always()
     steps:
       - name: Check required jobs
@@ -79,7 +80,6 @@ jobs:
           set -euo pipefail
 
           # Single required check for branch protection.
-          # Accept "skipped" for conditionally-run jobs.
           results=(
             "analyze=${{ needs.analyze.result }}"
             "test=${{ needs.test.result }}"
@@ -90,7 +90,7 @@ jobs:
           for r in "${results[@]}"; do
             status="${r#*=}"
             case "$status" in
-              success|skipped) ;;
+              success) ;;
               cancelled)
                 echo "::error::Required job was cancelled: $r"
                 exit 1

--- a/.github/workflows/jar-app.yaml
+++ b/.github/workflows/jar-app.yaml
@@ -67,6 +67,41 @@ jobs:
           github_token: ${{ secrets.GITHUB_TOKEN }}
           java-version: ${{ inputs.java-version }}
 
+  merge-gate:
+    name: Merge gate
+    needs: [analyze, test, build]
+    runs-on: ubuntu-latest
+    if: always()
+    steps:
+      - name: Check required jobs
+        shell: bash
+        run: |
+          set -euo pipefail
+
+          # Single required check for branch protection.
+          # Accept "skipped" for conditionally-run jobs.
+          results=(
+            "analyze=${{ needs.analyze.result }}"
+            "test=${{ needs.test.result }}"
+            "build=${{ needs.build.result }}"
+          )
+          printf '%s\n' "${results[@]}"
+
+          for r in "${results[@]}"; do
+            status="${r#*=}"
+            case "$status" in
+              success|skipped) ;;
+              cancelled)
+                echo "::error::Required job was cancelled: $r"
+                exit 1
+                ;;
+              *)
+                echo "::error::Required job failed: $r"
+                exit 1
+                ;;
+            esac
+          done
+
   deploy-dev:
     if: ${{ github.actor != 'dependabot[bot]' && github.event.pull_request.draft == false }}
     name: Deploy to dev

--- a/.github/workflows/next-app-v2.yaml
+++ b/.github/workflows/next-app-v2.yaml
@@ -100,6 +100,42 @@ jobs:
           NPM_AUTH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           node-version: ${{ inputs.node-version }}
 
+  merge-gate:
+    name: Merge gate
+    needs: [test-and-verify, build-dev, build-demo, build-prod]
+    runs-on: ubuntu-latest
+    if: always()
+    steps:
+      - name: Check required jobs
+        shell: bash
+        run: |
+          set -euo pipefail
+
+          # Single required check for branch protection.
+          # Accept "skipped" for conditionally-run jobs (e.g. build-prod only on main).
+          results=(
+            "test-and-verify=${{ needs.test-and-verify.result }}"
+            "build-dev=${{ needs.build-dev.result }}"
+            "build-demo=${{ needs.build-demo.result }}"
+            "build-prod=${{ needs.build-prod.result }}"
+          )
+          printf '%s\n' "${results[@]}"
+
+          for r in "${results[@]}"; do
+            status="${r#*=}"
+            case "$status" in
+              success|skipped) ;;
+              cancelled)
+                echo "::error::Required job was cancelled: $r"
+                exit 1
+                ;;
+              *)
+                echo "::error::Required job failed: $r"
+                exit 1
+                ;;
+            esac
+          done
+
   deploy-dev:
     if: ${{ github.event_name != 'merge_group' && !startsWith(github.ref_name, 'demo') && github.actor != 'dependabot[bot]' && github.event.pull_request.draft == false }}
     name: Deploy to dev

--- a/.github/workflows/next-app-v2.yaml
+++ b/.github/workflows/next-app-v2.yaml
@@ -102,8 +102,9 @@ jobs:
 
   merge-gate:
     name: Merge gate
-    needs: [test-and-verify, build-dev, build-demo, build-prod]
+    needs: [test-and-verify, build-dev]
     runs-on: ubuntu-latest
+    permissions: {}
     if: always()
     steps:
       - name: Check required jobs
@@ -112,12 +113,10 @@ jobs:
           set -euo pipefail
 
           # Single required check for branch protection.
-          # Accept "skipped" for conditionally-run jobs (e.g. build-prod only on main).
+          # Accept "skipped" for conditionally-run jobs.
           results=(
             "test-and-verify=${{ needs.test-and-verify.result }}"
             "build-dev=${{ needs.build-dev.result }}"
-            "build-demo=${{ needs.build-demo.result }}"
-            "build-prod=${{ needs.build-prod.result }}"
           )
           printf '%s\n' "${results[@]}"
 


### PR DESCRIPTION
## Summary
- add a Merge gate job to jar-app reusable workflows to aggregate analyze, test, and build results
- add the same Merge gate pattern to boot-jar-app and next-app-v2 workflows
- keep deploy job dependencies unchanged so deployment behavior stays the same

## Testing
- ruby YAML parse for updated workflows
- git diff --check

Closes #149