### PR TITLE
chore(codeql): upgrade codeql-action hash across workflows

### DIFF
--- a/.github/workflows/boot-jar-app.yaml
+++ b/.github/workflows/boot-jar-app.yaml
@@ -29,7 +29,7 @@ jobs:
           distribution: "temurin"
           java-version: ${{inputs.java-version}}
       - name: Initialize CodeQL
-        uses: github/codeql-action/init@0d579ffd059c29b07949a3cce3983f0780820c98 # v4
+        uses: github/codeql-action/init@95e58e9a2cdfd71adc6e0353d5c52f41a045d225 # v4
         with:
           languages: ${{ matrix.language }}
       - name: Build bootJar artifacts
@@ -39,7 +39,7 @@ jobs:
           ORG_GRADLE_PROJECT_githubUser: x-access-token
           ORG_GRADLE_PROJECT_githubPassword: ${{ secrets.GITHUB_TOKEN }}
       - name: Perform CodeQL Analysis
-        uses: github/codeql-action/analyze@0d579ffd059c29b07949a3cce3983f0780820c98 # v4
+        uses: github/codeql-action/analyze@95e58e9a2cdfd71adc6e0353d5c52f41a045d225 # v4
         with:
           category: "/language:${{matrix.language}}"
 

--- a/.github/workflows/fss-boot-jar-app.yaml
+++ b/.github/workflows/fss-boot-jar-app.yaml
@@ -29,7 +29,7 @@ jobs:
           distribution: "temurin"
           java-version: ${{inputs.java-version}}
       - name: Initialize CodeQL
-        uses: github/codeql-action/init@0d579ffd059c29b07949a3cce3983f0780820c98 # v4
+        uses: github/codeql-action/init@95e58e9a2cdfd71adc6e0353d5c52f41a045d225 # v4
         with:
           languages: ${{ matrix.language }}
       - name: Build bootJar artifacts
@@ -39,7 +39,7 @@ jobs:
           ORG_GRADLE_PROJECT_githubUser: x-access-token
           ORG_GRADLE_PROJECT_githubPassword: ${{ secrets.GITHUB_TOKEN }}
       - name: Perform CodeQL Analysis
-        uses: github/codeql-action/analyze@0d579ffd059c29b07949a3cce3983f0780820c98 # v4
+        uses: github/codeql-action/analyze@95e58e9a2cdfd71adc6e0353d5c52f41a045d225 # v4
         with:
           category: "/language:${{matrix.language}}"
 

--- a/.github/workflows/jar-app.yaml
+++ b/.github/workflows/jar-app.yaml
@@ -20,7 +20,7 @@ jobs:
       fail-fast: false
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
-      - uses: github/codeql-action/init@0d579ffd059c29b07949a3cce3983f0780820c98 # v4
+      - uses: github/codeql-action/init@95e58e9a2cdfd71adc6e0353d5c52f41a045d225 # v4
         with:
           languages: kotlin
           tools: linked

--- a/.github/workflows/jar-app.yaml
+++ b/.github/workflows/jar-app.yaml
@@ -34,7 +34,7 @@ jobs:
           JAVA_OPTS: "-Xmx2g -XX:MaxMetaspaceSize=1g"
           ORG_GRADLE_PROJECT_githubUser: x-access-token
           ORG_GRADLE_PROJECT_githubPassword: ${{ secrets.GITHUB_TOKEN }}
-      - uses: github/codeql-action/analyze@0d579ffd059c29b07949a3cce3983f0780820c98 # v4
+      - uses: github/codeql-action/analyze@95e58e9a2cdfd71adc6e0353d5c52f41a045d225 # v4
         with:
           category: "/language:kotlin"
 


### PR DESCRIPTION
## Hva er endret?

Oppgraderer `github/codeql-action` (init og analyze) til ny konsistent hash på tvers av alle reusable workflows.

### Endrede filer
- `.github/workflows/boot-jar-app.yaml`
- `.github/workflows/fss-boot-jar-app.yaml`
- `.github/workflows/jar-app.yaml`

### Detaljer
Oppdaterer hash fra `0d579ffd059c29b07949a3cce3983f0780820c98` til `95e58e9a2cdfd71adc6e0353d5c52f41a045d225` for både `codeql-action/init` og `codeql-action/analyze` i alle tre workflow-filene.