### PR TITLE
chore: run gradlew check in boot-jar workflow

### DIFF
--- a/.github/workflows/boot-jar-app.yaml
+++ b/.github/workflows/boot-jar-app.yaml
@@ -44,13 +44,14 @@ jobs:
           category: "/language:${{matrix.language}}"
 
   test:
-    name: Test
+    name: Check lint and test
     runs-on: ubuntu-latest
     steps:
       - uses: navikt/teamesyfo-github-actions-workflows/actions/gradle-cached@main
         with:
           java-version: ${{inputs.java-version}}
-      - run: ./gradlew test
+      - name: Run Gradle check (lint and test)
+        run: ./gradlew check
         env:
           ORG_GRADLE_PROJECT_githubUser: x-access-token
           ORG_GRADLE_PROJECT_githubPassword: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
## Summary
- replace `./gradlew test` with `./gradlew check` in `boot-jar-app.yaml`
- clarify in the workflow UI that the check job runs linting and tests

## Why
`./gradlew check` runs both ktlint checks and tests, so the workflow better matches the desired validation.