### PR TITLE
feat(build-next-app): aktiver Next.js skew protection med NEXT_DEPLOYMENT_ID

### DIFF
--- a/actions/build-next-app/action.yaml
+++ b/actions/build-next-app/action.yaml
@@ -45,6 +45,7 @@ runs:
       run: pnpm run build
       env:
         NEXT_PUBLIC_VERSION: ${{ github.sha }}
+        NEXT_DEPLOYMENT_ID: ${{ github.sha }}
     - name: Upload static files to NAV CDN
       uses: nais/deploy/actions/cdn-upload/v2@fa754451577294aae42872a69b888b3470478ec1 # v2 (master)
       if: ${{ github.actor != 'dependabot[bot]' }}


### PR DESCRIPTION
## Endring

Legger til `NEXT_DEPLOYMENT_ID=${{ github.sha }}` i build-steget i `build-next-app` action.

Next.js leser denne automatisk og baker den inn i standalone-builden. Ved rolling deployments vil klienter med gammel JS få full page reload i stedet for `UnrecognizedActionError` på server actions.

## CDN-merknad

`?dpl=<sha>` legges til på asset-URL-er, noe som kan gi ekstra CDN-misser etter deploy (fragmentering av cache-nøkler). Vurdert som akseptabelt fordi:
- Løser et **krasj i prod** — CDN-fragmentering er en ytelseskostnad
- Next.js bruker allerede content-hashede filnavn, så misser er kortvarige
- Kan adresseres separat via CDN-config om det blir et problem

## Avgrensning

Endringen gjelder kun `build-next-app` (pnpm). `next-to-docker` (npm/legacy) er bevisst utelatt.

Closes #166