### PR TITLE
chore: extend demo branch TTL from 2 to 7 days in workflows and update README

### DIFF
--- a/.github/workflows/next-app-v2.yaml
+++ b/.github/workflows/next-app-v2.yaml
@@ -189,7 +189,7 @@ jobs:
         env:
           CLUSTER: dev-gcp
           RESOURCE: nais/nais-demo.yaml
-          VAR: image=${{ needs.build-demo.outputs.image }},ingress=https://${{ steps.slug.outputs.slug }}.ekstern.dev.nav.no${{ inputs.base-path }},appname=${{ steps.slug.outputs.slug }},replicas=1,branchState=alive,ttl=48h
+          VAR: image=${{ needs.build-demo.outputs.image }},ingress=https://${{ steps.slug.outputs.slug }}.ekstern.dev.nav.no${{ inputs.base-path }},appname=${{ steps.slug.outputs.slug }},replicas=1,branchState=alive,ttl=168h
 
   deploy-prod:
     if: github.event_name != 'merge_group' && github.ref_name == 'main'

--- a/.github/workflows/next-app.yaml
+++ b/.github/workflows/next-app.yaml
@@ -129,7 +129,7 @@ jobs:
         env:
           CLUSTER: dev-gcp
           RESOURCE: nais/nais-demo.yaml
-          VAR: image=${{ needs.build-demo.outputs.image }},ingress=https://${{ steps.slug.outputs.slug }}.ekstern.dev.nav.no${{ inputs.base-path }},appname=${{ steps.slug.outputs.slug }},replicas=1,branchState=alive,ttl=48h
+          VAR: image=${{ needs.build-demo.outputs.image }},ingress=https://${{ steps.slug.outputs.slug }}.ekstern.dev.nav.no${{ inputs.base-path }},appname=${{ steps.slug.outputs.slug }},replicas=1,branchState=alive,ttl=168h
 
   build-prod:
     if: ${{ github.ref_name == 'main' }}

--- a/README.md
+++ b/README.md
@@ -17,7 +17,7 @@ flowchart TD
     D --> H[deploy-prod]
 ```
 
-Builds 1 app per environment. Supports deploying demo-prefixed branches to their own ingress. Demo-applications will be deleted in 48 hours.
+Builds 1 app per environment. Supports deploying demo-prefixed branches to their own ingress. Demo apps for demo branches will be deleted in 7 days.
 
 <details>
 <summary>Detailed instructions</summary>
@@ -142,11 +142,11 @@ The current implementation uses `GITHUB_TOKEN` to approve the PR, then creates a
 
 #### Policy
 
-| Update type | Auto-merged? |
-|-------------|-------------|
-| GitHub Actions | ✅ Yes, including major |
-| Patch (non-GitHub Actions) | ✅ Yes |
-| Minor (non-GitHub Actions) | ✅ Yes |
+| Update type                | Auto-merged?                   |
+| -------------------------- | ------------------------------ |
+| GitHub Actions             | ✅ Yes, including major        |
+| Patch (non-GitHub Actions) | ✅ Yes                         |
+| Minor (non-GitHub Actions) | ✅ Yes                         |
 | Major (non-GitHub Actions) | ❌ No — requires manual review |
 
 The policy applies to both production and development dependencies.


### PR DESCRIPTION
2 dager er litt lite, da rekker ikke alltid andre (designer, jurist...) å få sett før demo-appen blir slettet. Endrer til 7 dager.

Endret til 168d og ikke 7d fordi TTL tydeligvis være på "go-format", og "7d" støttes ikke:

> Because the NAIS API validator for Application TTL literally parses it with Go’s duration parser.
> 
> Direct proof in source:
> - https://raw.githubusercontent.com/nais/liberator/master/pkg/apis/nais.io/v1alpha1/webhook.go
> - It validates with: time.ParseDuration(a.Spec.TTL)
> - It returns this error text if invalid: TTL is not a valid duration ... Example of valid duration is '12h'
> - The mutator also uses time.ParseDuration(app.Spec.TTL) to compute kill-after label
> 
> That means TTL must follow Go duration syntax (hours/minutes/seconds etc.), which is why 48h is valid and 7d is not.